### PR TITLE
remove `.json` from `.cargo/config.toml`, swap to including nanos_sdk by version

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,11 +12,11 @@ build-std = ["core"]
 build-std-features = ["compiler-builtins-mem"]
 
 [build]
-target = "nanosplus.json"
+target = "nanosplus"
 
 [alias]
-bns = "build --example gadgets --release --features speculos --target=nanos.json"
-bnsp = "build --example gadgets --release --features speculos --target=nanosplus.json"
-rns = "run --example gadgets --release --features speculos --target=nanos.json"
-rnx = "run --example gadgets --release --features speculos --target=nanox.json"
-rnsp = "run --example gadgets --release --features speculos --target=nanosplus.json"
+bns = "build --example gadgets --release --features speculos --target=nanos"
+bnsp = "build --example gadgets --release --features speculos --target=nanosplus"
+rns = "run --example gadgets --release --features speculos --target=nanos"
+rnx = "run --example gadgets --release --features speculos --target=nanox"
+rnsp = "run --example gadgets --release --features speculos --target=nanosplus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["yhql"]
 edition = "2021"
 
 [dependencies]
-nanos_sdk = { git = "https://github.com/LedgerHQ/ledger-nanos-sdk" } 
+nanos_sdk = { version = "0.2.0" } 
 include_gif = { git = "https://github.com/LedgerHQ/sdk_include_gif" }
 
 [features]


### PR DESCRIPTION
- using `target.json` in `cargo/config.toml` works with `--target=something.json` but seemingly not with `RUST_TARGET_PATH`, while `target` works with either.
- non-critical but, using a version include for `nanos_sdk` makes patching slightly more obvious for most users

instructions for testing would then be to patch both:
```
[patch.crates-io]
nanos_sdk = { git = "https://github.com/LedgerHQ/ledger-nanos-sdk.git", branch = "master" }
nanos_ui = { git = "https://github.com/LedgerHQ/ledger-nanos-ui.git", branch = "all_targets" }
```

otherwise as it stands (if you're using a crates.io dep) you also need to:
```
[patch."https://github.com/LedgerHQ/ledger-nanos-sdk"]
nanos_sdk = { git = "https://github.com/LedgerHQ/ledger-nanos-sdk.git", branch = "master" }
```