### PR TITLE
Make the Icon::from public

### DIFF
--- a/src/bagls/se.rs
+++ b/src/bagls/se.rs
@@ -85,7 +85,7 @@ impl<'a> From<&'a Glyph<'a>> for Icon<'a> {
 }
 
 impl<'a> Icon<'a> {
-    const fn from(glyph: &'a Glyph<'a>) -> Icon<'a> {
+    pub const fn from(glyph: &'a Glyph<'a>) -> Icon<'a> {
         Icon {
             icon: glyph,
             pos: (0, middle_y(glyph)),


### PR DESCRIPTION
This is required to make `const` Icon(s) in another crate.