### PR TITLE
Fix default state for the Validator::ask. 

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -86,7 +86,7 @@ impl<'a> Validator<'a> {
         };
         redraw(&lines);
 
-        let mut response = true;
+        let mut response = false;
 
         loop {
             match get_event(&mut buttons) {


### PR DESCRIPTION
By default, UI highlights `Cancel` text, but if the user immediately presses both buttons, the returned value is `true`. The fix makes state of the UI and returned value match each other.