### PR TITLE
Fix sizing for bitmaps for Nano X v2.2.x

### DIFF
--- a/src/bagls/se.rs
+++ b/src/bagls/se.rs
@@ -121,7 +121,7 @@ fn pic_draw(x: i32, y: i32, width: u32, height: u32, inverted: bool, bitmap: &[u
             inverted.as_ptr(),
             1,
             pic_bmp as *const u8,
-            (bitmap.len() * 8) as u32,
+            width * height,
         )
     }
 }


### PR DESCRIPTION
Invalid length prevented icons from being drawn.