### PR TITLE
UI fixes

### DIFF
--- a/examples/gadgets.rs
+++ b/examples/gadgets.rs
@@ -99,17 +99,34 @@ extern "C" fn sample_main() {
     use nanos_ui::bagls::RectFull as Rect;
     use nanos_ui::layout::Draw;
 
-    Rect::new().width(10).height(10).pos(16, 16).display();
-    Rect::new().width(10).height(10).pos(32, 16).display();
-    Rect::new().width(10).height(10).pos(48, 16).display();
+    Rect::new()
+        .width(10)
+        .height(10)
+        .pos(16, 16)
+        .instant_display();
+    Rect::new()
+        .width(10)
+        .height(10)
+        .pos(32, 16)
+        .instant_display();
+    Rect::new()
+        .width(10)
+        .height(10)
+        .pos(48, 16)
+        .instant_display();
     wait_any();
 
+    ui::clear_screen();
+
     let checkmark = nanos_ui::bagls::CHECKMARK_ICON.set_x(0).set_y(4);
-    checkmark.display();
-    nanos_ui::bagls::CROSS_ICON.set_x(20).set_y(4).display();
-    nanos_ui::bagls::COGGLE.set_x(40).set_y(4).display();
+    checkmark.instant_display();
+    nanos_ui::bagls::CROSS_ICON
+        .set_x(20)
+        .set_y(4)
+        .instant_display();
+    nanos_ui::bagls::COGGLE.set_x(40).set_y(4).instant_display();
     wait_any();
-    checkmark.erase();
+    checkmark.instant_erase();
     wait_any();
 
     nanos_sdk::exit_app(0);

--- a/src/bagls/se.rs
+++ b/src/bagls/se.rs
@@ -79,7 +79,6 @@ impl Draw for RectFull {
             self.width,
             self.height,
         );
-        nanos_sdk::screen::sdk_screen_update();
     }
 
     fn erase(&self) {
@@ -90,7 +89,6 @@ impl Draw for RectFull {
             self.width,
             self.height,
         );
-        nanos_sdk::screen::sdk_screen_update();
     }
 }
 

--- a/src/bagls/se.rs
+++ b/src/bagls/se.rs
@@ -53,16 +53,18 @@ impl Draw for Label<'_> {
     fn erase(&self) {
         let total_width = self.text.compute_width(self.bold);
         let c_height = OPEN_SANS[self.bold as usize].height as usize;
-        let x = self.layout.get_x(total_width);
-        let y = self.loc.get_y(c_height);
-        pic_draw(
-            x as i32,
-            y as i32,
-            total_width as u32,
-            c_height as u32,
-            false,
-            &crate::bitmaps::BLANK,
-        )
+        if total_width != 0 {
+            let x = self.layout.get_x(total_width);
+            let y = self.loc.get_y(c_height);
+            pic_draw(
+                x as i32,
+                y as i32,
+                total_width as u32,
+                c_height as u32,
+                false,
+                &crate::bitmaps::BLANK,
+            )
+        }
     }
 }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -58,6 +58,10 @@ pub trait Draw {
         self.display();
         crate::screen_util::screen_update();
     }
+    fn instant_erase(&self) {
+        self.erase();
+        crate::screen_util::screen_update();
+    }
     fn display(&self);
     fn erase(&self);
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -39,7 +39,10 @@ pub fn clear_screen() {
         #[cfg(feature = "speculos")]
         {
             // Speculos does not emulate the screen_clear syscall yet
-            RectFull::new().width(crate::SCREEN_WIDTH as u32).height(crate::SCREEN_HEIGHT as u32).erase();
+            RectFull::new()
+                .width(crate::SCREEN_WIDTH as u32)
+                .height(crate::SCREEN_HEIGHT as u32)
+                .erase();
         }
     }
 
@@ -368,6 +371,8 @@ impl<'a> MessageScroller<'a> {
             let chunk = &self.message[start..end];
             label.erase();
             label.text = &chunk;
+            LEFT_ARROW.erase();
+            RIGHT_ARROW.erase();
             if page > 0 {
                 LEFT_ARROW.display();
             }


### PR DESCRIPTION
- Prevent sending illegal draw request with 0 width by not trying to erase empty strings (MessageScroller)
- Add an `.instant_erase()` to match `.instant_display()` and remove auto screen update on `Rect` draw methods to make behaviour more consistent. Update the `gadgets.rs` example to match.
- (MessageScroller) left arrow on first screen and right arrow on last were still display after going through once, this has been fixed.