### PR TITLE
fix: align function signatures in `Label`

### DIFF
--- a/src/bagls/mcu.rs
+++ b/src/bagls/mcu.rs
@@ -153,7 +153,7 @@ impl<'a> Label<'a> {
         }
     }
 
-    pub const fn from_const(text: &'static str) -> Self {
+    pub const fn from_const(text: &'a str) -> Self {
         Label {
             loc: Location::Middle,
             layout: Layout::Centered,
@@ -178,7 +178,7 @@ impl<'a> Label<'a> {
     pub const fn bold(self) -> Self {
         Label { bold: true, ..self }
     }
-    pub fn text(self, text: &'a str) -> Self {
+    pub const fn text(self, text: &'a str) -> Self {
         Label { text, ..self }
     }
 }


### PR DESCRIPTION
Some functions in `mcu::Label` are not compatible with the `se::Label` ones.

This PR aligns function signatures to be compatible with different targets.