### PR TITLE
Add new gadgets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 ledger-sdk-sys = { git = "https://github.com/LedgerHQ/secure-sdk-rust" }
+nanos_sdk = { git = "https://github.com/LedgerHQ/ledger-nanos-sdk.git" }
 include_gif = { git = "https://github.com/LedgerHQ/sdk_include_gif" }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 ledger-sdk-sys = { git = "https://github.com/LedgerHQ/secure-sdk-rust" }
 nanos_sdk = { git = "https://github.com/LedgerHQ/ledger-nanos-sdk.git" }
 include_gif = { git = "https://github.com/LedgerHQ/sdk_include_gif" }
+numtoa = "0.2.4"
 
 [features]
 speculos = []

--- a/src/bagls/mcu.rs
+++ b/src/bagls/mcu.rs
@@ -379,12 +379,19 @@ impl<'a> SendToDisplay for Label<'a> {
         };
         let x = match self.layout {
             Layout::RightAligned => self.layout.get_x(self.text.len() * 7),
+            Layout::Custom(x) => x as usize,
             _ => 0,
         };
         let y = self.loc.get_y(self.dims.1 as usize) as i16;
         let width = match self.layout {
             Layout::Centered => crate::SCREEN_WIDTH,
             _ => self.text.len() * 6,
+        };
+        let alignment = match self.layout {
+            Layout::LeftAligned => 0 as u16,
+            Layout::Centered => BAGL_FONT_ALIGNMENT_CENTER as u16,
+            Layout::RightAligned => BAGL_FONT_ALIGNMENT_CENTER as u16,
+            Layout::Custom(_) => 0 as u16,
         };
         let baglcomp = BaglComponent {
             type_: BaglTypes::LabelLine as u8,
@@ -398,7 +405,7 @@ impl<'a> SendToDisplay for Label<'a> {
             fill: 0,
             fgcolor: 0xffffffu32,
             bgcolor: 0,
-            font_id: font_id as u16 | BAGL_FONT_ALIGNMENT_CENTER as u16,
+            font_id: font_id as u16 | alignment,
             icon_id: 0,
         };
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -3,6 +3,7 @@ pub enum Layout {
     LeftAligned,
     RightAligned,
     Centered,
+    Custom(usize),
 }
 
 impl Layout {
@@ -11,6 +12,7 @@ impl Layout {
             Layout::LeftAligned => crate::PADDING,
             Layout::Centered => (crate::SCREEN_WIDTH - width) / 2,
             Layout::RightAligned => crate::SCREEN_WIDTH - crate::PADDING - width,
+            Layout::Custom(x) => *x,
         }
     }
 }
@@ -26,9 +28,9 @@ pub enum Location {
 impl Location {
     pub fn get_y(&self, height: usize) -> usize {
         match self {
-            Location::Top => 0,
+            Location::Top => crate::Y_PADDING,
             Location::Middle => (crate::SCREEN_HEIGHT - height) / 2,
-            Location::Bottom => crate::SCREEN_HEIGHT - height,
+            Location::Bottom => crate::SCREEN_HEIGHT - height - crate::Y_PADDING,
             Location::Custom(y) => *y,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod screen_util;
 pub mod ui;
 
 pub const PADDING: usize = 2;
+pub const Y_PADDING: usize = 3;
 pub const SCREEN_WIDTH: usize = 128;
 
 #[cfg(target_os = "nanos")]

--- a/src/string_se.rs
+++ b/src/string_se.rs
@@ -52,7 +52,7 @@ impl StringPlace for [&str] {
 
     fn place(&self, loc: Location, layout: Layout, bold: bool) {
         let c_height = OPEN_SANS[bold as usize].height as usize;
-        let padding = if self.len() > 4 { 0 } else { 2 };
+        let padding = if self.len() > 4 { 0 } else { 1 };
         let total_height = self.len() * (c_height + padding);
         let mut cur_y = loc.get_y(total_height);
         for string in self.iter() {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -14,6 +14,10 @@ use crate::layout::{Draw, Location, StringPlace};
 
 use crate::bitmaps::Glyph;
 
+use numtoa::NumToA;
+
+const MAX_CHAR_PER_LINE: usize = 18;
+
 /// Handles communication to filter
 /// out actual events, and converts key
 /// events into presses/releases
@@ -311,6 +315,7 @@ impl<'a> Menu<'a> {
     }
 }
 
+#[derive(Copy, Clone)]
 pub enum PageStyle {
     PictureNormal, // Picture (should be 16x16) with two lines of text (page layout depends on device).
     PictureBold,   // Icon on top with one line of text on the bottom.
@@ -318,10 +323,13 @@ pub enum PageStyle {
     Normal,        // 2 lines of centered text.
 }
 
+#[derive(Copy, Clone)]
 pub struct Page<'a> {
     style: PageStyle,
     label: [&'a str; 2],
     glyph: Option<&'a Glyph<'a>>,
+    chunk_count: u8,
+    chunk_idx: u8,
 }
 
 // new_picture_normal
@@ -354,17 +362,37 @@ impl<'a> From<(&'a str, &'a Glyph<'a>)> for Page<'a> {
 
 impl<'a> Page<'a> {
     pub fn new(style: PageStyle, label: [&'a str; 2], glyph: Option<&'a Glyph<'a>>) -> Self {
+        let chunk_count = 0;
+        let chunk_idx = 0;
         Page {
             style,
             label,
             glyph,
+            chunk_count,
+            chunk_idx,
         }
     }
 
-    }
-
     pub fn place(&self) {
-        clear_screen();
+        let mut label_bytes = [0u8; MAX_CHAR_PER_LINE];
+        let mut label_str: &str = "";
+        // Notes: 
+        // * chunk_count and chunk_idx are only used for multi-page fields
+        //   and are set to 0 by default. MultiFieldReview is the only place where
+        //   these values are set.
+        // * Only pages of style BoldNormal will display the chunk count and index. 
+        if self.chunk_count > 1 {
+            // Convert the chunk count to a string
+            let mut chunk_count_buf = [0u8;3]; 
+            let chunk_count_str = self.chunk_count.numtoa_str(10,&mut chunk_count_buf);  
+            // Convert the chunk index to a string
+            let mut chunk_idx_buf = [0u8;3]; 
+            let chunk_idx_str = self.chunk_idx.numtoa_str(10,&mut chunk_idx_buf); 
+            // Add the chunk count and index to the label
+            concatenate(&[self.label[0], " (", chunk_idx_str, "/", chunk_count_str, ")"], &mut label_bytes);
+            label_str = core::str::from_utf8(&mut label_bytes).unwrap();            
+        }
+
         match self.style {
             PageStyle::PictureNormal => {
                 let mut icon_x = 16;
@@ -410,7 +438,12 @@ impl<'a> Page<'a> {
                     + OPEN_SANS[1].height as usize
                     + 2 * padding as usize;
                 let mut cur_y = Location::Middle.get_y(total_height);
-                self.label[0].place(Location::Custom(cur_y), Layout::Centered, true);
+                if self.chunk_count > 1 {
+                    label_str.place(Location::Custom(cur_y), Layout::Centered, true);
+                }
+                else {
+                    self.label[0].place(Location::Custom(cur_y), Layout::Centered, true);
+                }
                 cur_y += OPEN_SANS[0].height as usize + 2 * padding as usize;
                 self.label[1].place(Location::Custom(cur_y), Layout::Centered, false);
             }
@@ -419,6 +452,22 @@ impl<'a> Page<'a> {
             }
         }
     }
+
+    pub fn place_and_wait(&self) {
+        let mut buttons = ButtonsState::new();
+
+        self.place();
+
+        loop {
+            match get_event(&mut buttons) {
+                Some(ButtonEvent::LeftButtonRelease)
+                | Some(ButtonEvent::RightButtonRelease)
+                | Some(ButtonEvent::BothButtonsRelease) => return,
+                _ => (),
+            }
+        }
+    }
+
 }
 
 pub enum EventOrPageIndex {
@@ -533,7 +582,7 @@ impl<'a> SingleMessage<'a> {
 /// A horizontal scroller that
 /// splits any given message
 /// over several panes in chunks
-/// of CHAR_N characters.
+/// of MAX_CHAR_PER_LINE characters.
 /// Press both buttons to exit.
 pub struct MessageScroller<'a> {
     message: &'a str,
@@ -547,8 +596,7 @@ impl<'a> MessageScroller<'a> {
     pub fn event_loop(&self) {
         clear_screen();
         let mut buttons = ButtonsState::new();
-        const CHAR_N: usize = 16;
-        let page_count = (self.message.len() - 1) / CHAR_N + 1;
+        let page_count = (self.message.len() - 1) / MAX_CHAR_PER_LINE + 1;
         if page_count == 0 {
             return;
         }
@@ -558,8 +606,8 @@ impl<'a> MessageScroller<'a> {
         // A closure to draw common elements of the screen
         // cur_page passed as parameter to prevent borrowing
         let mut draw = |page: usize| {
-            let start = page * CHAR_N;
-            let end = (start + CHAR_N).min(self.message.len());
+            let start = page * MAX_CHAR_PER_LINE;
+            let end = (start + MAX_CHAR_PER_LINE).min(self.message.len());
             let chunk = &self.message[start..end];
             label.erase();
             label.text = &chunk;
@@ -602,6 +650,157 @@ impl<'a> MessageScroller<'a> {
                 }
                 Some(ButtonEvent::BothButtonsRelease) => break,
                 Some(_) | None => (),
+            }
+        }
+    }
+}
+
+pub struct Field<'a> {
+    pub name: &'a str,
+    pub value: &'a str,
+}
+pub struct MultiFieldReview<'a> {
+    fields: &'a [Field<'a>],
+    review_message: &'a[&'a str],
+    review_glyph: Option<&'a Glyph<'a>>,
+    validation_message: &'a str,
+    validation_glyph: Option<&'a Glyph<'a>>,
+    cancel_message: &'a str,
+    cancel_glyph: Option<&'a Glyph<'a>>,
+}
+
+// Function to concatenate multiple strings into a fixed-size array
+fn concatenate(strings: &[&str], output: &mut [u8]) {
+    let mut offset = 0;
+
+    for s in strings {
+        let s_len = s.len();
+        let copy_len = core::cmp::min(s_len, output.len() - offset);
+
+        if copy_len > 0 {
+            output[offset..offset + copy_len].copy_from_slice(&s.as_bytes()[..copy_len]);
+            offset += copy_len;
+        } else {
+            // If the output buffer is full, stop concatenating.
+            break;
+        }
+    }
+}
+
+impl<'a> MultiFieldReview<'a> {
+    pub fn new(fields: &'a [Field<'a>],
+               review_message: &'a [&'a str],
+               review_glyph: Option<&'a Glyph<'a>>,
+               validation_message: &'a str,
+               validation_glyph: Option<&'a Glyph<'a>>,
+               cancel_message: &'a str,
+               cancel_glyph: Option<&'a Glyph<'a>>) -> Self {
+        MultiFieldReview {
+            fields,
+            review_message,
+            review_glyph,
+            validation_message,
+            validation_glyph,
+            cancel_message,
+            cancel_glyph,
+        }
+    }
+
+    pub fn show(&self) -> bool {
+        let mut buttons = ButtonsState::new();
+
+        let first_page = match self.review_message.len() {
+            0 => {
+                Page::new(PageStyle::PictureNormal, ["", ""], self.review_glyph)
+            }
+            1 => {
+                Page::new(PageStyle::PictureBold, [self.review_message[0], ""], self.review_glyph)
+            }
+            _ => {
+                Page::new(PageStyle::PictureNormal, [self.review_message[0], self.review_message[1]], self.review_glyph)
+            }
+        };
+        let validation_page = Page::new(PageStyle::PictureBold, [self.validation_message, ""], self.validation_glyph);
+        let cancel_page = Page::new(PageStyle::PictureBold, [self.cancel_message, ""], self.cancel_glyph);
+        let mut review_pages: [Page; 32] = [Page::new(PageStyle::Normal, ["", ""], None); 32];
+        let mut total_page_count = 0;
+ 
+        // Determine each field page count
+        for field in self.fields {
+            let field_page_count = (field.value.len() - 1) / MAX_CHAR_PER_LINE + 1;
+            // Create pages for each chunk of the field            
+            for i in 0..field_page_count {
+                let start = i * MAX_CHAR_PER_LINE;
+                let end = (start + MAX_CHAR_PER_LINE).min(field.value.len());
+                let chunk = &field.value[start..end];
+                review_pages[total_page_count] = Page::new(PageStyle::BoldNormal, [field.name, chunk], None);
+                review_pages[total_page_count].chunk_count = field_page_count as u8;
+                review_pages[total_page_count].chunk_idx = (i + 1) as u8;
+                total_page_count += 1;
+            }
+        }
+
+        review_pages[total_page_count] = validation_page;
+        total_page_count += 1;
+        review_pages[total_page_count] = cancel_page;
+
+        clear_screen();
+        first_page.place_and_wait();
+        crate::screen_util::screen_update();
+        clear_screen();
+        RIGHT_ARROW.display();
+
+        let mut cur_page = 0;
+        review_pages[cur_page].place();
+
+        loop {
+            match get_event(&mut buttons) {
+                Some(ButtonEvent::LeftButtonPress) => {
+                    if cur_page > 0 {
+                        LEFT_S_ARROW.instant_display();
+                    }
+                }
+                Some(ButtonEvent::RightButtonPress) => {
+                    if cur_page < total_page_count {
+                        RIGHT_S_ARROW.instant_display();
+                    }
+                }
+                Some(b) => {
+                    match b {
+                        ButtonEvent::LeftButtonRelease => {
+                            if cur_page > 0 {
+                                cur_page -= 1;
+                            }
+                        }
+                        ButtonEvent::RightButtonRelease => {
+                            if cur_page < total_page_count {
+                                cur_page += 1;
+                            }
+                        }
+                        ButtonEvent::BothButtonsRelease => 
+                        {
+                            if cur_page == total_page_count {
+                                // Cancel
+                                return false;
+                            }
+                            else if cur_page == total_page_count - 1 {
+                                // Validate
+                                return true;
+                            }
+                        }
+                        _ => (),
+                    }
+                    clear_screen();
+                    review_pages[cur_page].place();
+                    if cur_page > 0 {
+                        LEFT_ARROW.display();
+                    }
+                    if cur_page < total_page_count {
+                        RIGHT_ARROW.display();
+                    }
+                    crate::screen_util::screen_update();
+                }
+                _ => (),
             }
         }
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,11 +1,15 @@
 #![allow(dead_code)]
 
+use core::str::from_utf8;
+
 use ledger_sdk_sys::{
     buttons::{get_button_event, ButtonEvent, ButtonsState},
     seph,
 };
 
-use nanos_sdk::{io, buttons::ButtonEvent::*};
+use nanos_sdk::{buttons::ButtonEvent::*, io};
+
+use nanos_sdk::testing;
 
 use crate::{bagls::*, fonts::OPEN_SANS};
 
@@ -16,7 +20,7 @@ use crate::bitmaps::Glyph;
 
 use numtoa::NumToA;
 
-const MAX_CHAR_PER_LINE: usize = 18;
+const MAX_CHAR_PER_LINE: usize = 17;
 
 /// Handles communication to filter
 /// out actual events, and converts key
@@ -43,7 +47,6 @@ pub fn get_event(buttons: &mut ButtonsState) -> Option<ButtonEvent> {
 pub fn clear_screen() {
     #[cfg(not(target_os = "nanos"))]
     {
-
         #[cfg(not(feature = "speculos"))]
         unsafe {
             ledger_sdk_sys::screen_clear();
@@ -315,7 +318,7 @@ impl<'a> Menu<'a> {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum PageStyle {
     PictureNormal, // Picture (should be 16x16) with two lines of text (page layout depends on device).
     PictureBold,   // Icon on top with one line of text on the bottom.
@@ -335,7 +338,7 @@ pub struct Page<'a> {
 // new_picture_normal
 impl<'a> From<([&'a str; 2], &'a Glyph<'a>)> for Page<'a> {
     fn from((label, glyph): ([&'a str; 2], &'a Glyph<'a>)) -> Page<'a> {
-        Page::new(PageStyle::PictureNormal, label, Some(glyph))
+        Page::new(PageStyle::PictureNormal, [label[0], label[1]], Some(glyph))
     }
 }
 
@@ -343,11 +346,9 @@ impl<'a> From<([&'a str; 2], &'a Glyph<'a>)> for Page<'a> {
 impl<'a> From<([&'a str; 2], bool)> for Page<'a> {
     fn from((label, bold): ([&'a str; 2], bool)) -> Page<'a> {
         if bold {
-            Page::new(PageStyle::BoldNormal, label, None)
-        }
-        else
-        {
-            Page::new(PageStyle::Normal, label, None)
+            Page::new(PageStyle::BoldNormal, [label[0], label[1]], None)
+        } else {
+            Page::new(PageStyle::Normal, [label[0], label[1]], None)
         }
     }
 }
@@ -374,26 +375,10 @@ impl<'a> Page<'a> {
     }
 
     pub fn place(&self) {
-        let mut label_bytes = [0u8; MAX_CHAR_PER_LINE];
-        let mut label_str: &str = "";
-        // Notes: 
-        // * chunk_count and chunk_idx are only used for multi-page fields
-        //   and are set to 0 by default. MultiFieldReview is the only place where
-        //   these values are set.
-        // * Only pages of style BoldNormal will display the chunk count and index. 
-        if self.chunk_count > 1 {
-            // Convert the chunk count to a string
-            let mut chunk_count_buf = [0u8;3]; 
-            let chunk_count_str = self.chunk_count.numtoa_str(10,&mut chunk_count_buf);  
-            // Convert the chunk index to a string
-            let mut chunk_idx_buf = [0u8;3]; 
-            let chunk_idx_str = self.chunk_idx.numtoa_str(10,&mut chunk_idx_buf); 
-            // Add the chunk count and index to the label
-            concatenate(&[self.label[0], " (", chunk_idx_str, "/", chunk_count_str, ")"], &mut label_bytes);
-            label_str = core::str::from_utf8(&mut label_bytes).unwrap();            
-        }
-
         match self.style {
+            PageStyle::Normal => {
+                self.label.place(Location::Middle, Layout::Centered, false);
+            }
             PageStyle::PictureNormal => {
                 let mut icon_x = 16;
                 let mut icon_y = 8;
@@ -434,21 +419,65 @@ impl<'a> Page<'a> {
             }
             PageStyle::BoldNormal => {
                 let padding = 1;
-                let total_height = OPEN_SANS[0].height as usize
+                let mut max_text_lines = 3;
+                if cfg!(target_os = "nanos")
+                {
+                    max_text_lines = 1;
+                }
+                let total_height = (OPEN_SANS[0].height * max_text_lines)  as usize
                     + OPEN_SANS[1].height as usize
                     + 2 * padding as usize;
                 let mut cur_y = Location::Middle.get_y(total_height);
+                
+                // Display the chunk count and index if needed
                 if self.chunk_count > 1 {
-                    label_str.place(Location::Custom(cur_y), Layout::Centered, true);
-                }
-                else {
+                    let mut label_bytes = [0u8; MAX_CHAR_PER_LINE];
+                    // Convert the chunk count to a string
+                    let mut chunk_count_buf = [0u8; 3];
+                    let chunk_count_str = self.chunk_count.numtoa_str(10, &mut chunk_count_buf);
+                    // Convert the chunk index to a string
+                    let mut chunk_idx_buf = [0u8; 3];
+                    let chunk_idx_str = self.chunk_idx.numtoa_str(10, &mut chunk_idx_buf);
+                    // Add the chunk count and index to the label
+                    concatenate(
+                        &[
+                            self.label[0],
+                            " (",
+                            chunk_idx_str,
+                            "/",
+                            chunk_count_str,
+                            ")",
+                        ],
+                        &mut label_bytes,
+                    );
+                    from_utf8(&mut label_bytes).unwrap().trim_matches(char::from(0)).place(Location::Custom(cur_y), Layout::Centered, true);
+                } else {
                     self.label[0].place(Location::Custom(cur_y), Layout::Centered, true);
                 }
                 cur_y += OPEN_SANS[0].height as usize + 2 * padding as usize;
-                self.label[1].place(Location::Custom(cur_y), Layout::Centered, false);
-            }
-            PageStyle::Normal => {
-                self.label.place(Location::Middle, Layout::Centered, false);
+                
+                // If the device is a Nano S, display the second label as
+                // a single line of text
+                if cfg!(target_os = "nanos")
+                {
+                    self.label[1].place(Location::Custom(cur_y), Layout::Centered, false);
+                }
+                // Otherwise, display the second label as up to 3 lines of text
+                else {
+                    let mut indices = [(0, 0); 3];
+                    let len = self.label[1].len();
+                    for i in 0..3 {
+                        let start = (i * MAX_CHAR_PER_LINE).min(len);
+                        if start >= len {
+                            break; // Break if we reach the end of the string
+                        }
+                        let end = (start + MAX_CHAR_PER_LINE).min(len);
+                        indices[i] = (start, end);
+                        (&self.label[1][start..end]).place(Location::Custom(cur_y), Layout::Centered, false);
+                        cur_y += OPEN_SANS[0].height as usize + 2 * padding as usize;
+                        
+                    }
+                }
             }
         }
     }
@@ -467,27 +496,26 @@ impl<'a> Page<'a> {
             }
         }
     }
-
 }
 
 pub enum EventOrPageIndex {
     Event(io::Event<io::ApduHeader>),
-    Index(usize)
+    Index(usize),
 }
 
 pub struct MultiPageMenu<'a> {
-    comm : &'a mut io::Comm,
+    comm: &'a mut io::Comm,
     pages: &'a [&'a Page<'a>],
 }
 
 impl<'a> MultiPageMenu<'a> {
-    pub fn new(comm: &'a mut io::Comm,  pages: &'a [&'a Page]) -> Self {
+    pub fn new(comm: &'a mut io::Comm, pages: &'a [&'a Page]) -> Self {
         MultiPageMenu { comm, pages }
     }
 
     pub fn show(&mut self) -> EventOrPageIndex {
         clear_screen();
-        
+
         self.pages[0].place();
 
         LEFT_ARROW.display();
@@ -499,33 +527,31 @@ impl<'a> MultiPageMenu<'a> {
 
         loop {
             match self.comm.next_event() {
-                io::Event::Button(button) => {
-                    match button {
-                        BothButtonsRelease => return EventOrPageIndex::Index(index), 
-                        b => {
-                            match b {
-                                LeftButtonRelease => {
-                                    if index as i16 - 1 < 0 {
-                                        index = self.pages.len() - 1;
-                                    } else {
-                                        index = index.saturating_sub(1);
-                                    }
+                io::Event::Button(button) => match button {
+                    BothButtonsRelease => return EventOrPageIndex::Index(index),
+                    b => {
+                        match b {
+                            LeftButtonRelease => {
+                                if index as i16 - 1 < 0 {
+                                    index = self.pages.len() - 1;
+                                } else {
+                                    index = index.saturating_sub(1);
                                 }
-                                RightButtonRelease => {
-                                    if index < self.pages.len() - 1 {
-                                        index += 1;
-                                    } else {
-                                        index = 0;
-                                    }
-                                }
-                                _ => (),
                             }
-                            clear_screen();
-                            self.pages[index].place();
-                            LEFT_ARROW.display();
-                            RIGHT_ARROW.display();
-                            crate::screen_util::screen_update();
+                            RightButtonRelease => {
+                                if index < self.pages.len() - 1 {
+                                    index += 1;
+                                } else {
+                                    index = 0;
+                                }
+                            }
+                            _ => (),
                         }
+                        clear_screen();
+                        self.pages[index].place();
+                        LEFT_ARROW.display();
+                        RIGHT_ARROW.display();
+                        crate::screen_util::screen_update();
                     }
                 },
                 io::Event::Command(ins) => return EventOrPageIndex::Event(io::Event::Command(ins)),
@@ -653,7 +679,7 @@ pub struct Field<'a> {
 }
 pub struct MultiFieldReview<'a> {
     fields: &'a [Field<'a>],
-    review_message: &'a[&'a str],
+    review_message: &'a [&'a str],
     review_glyph: Option<&'a Glyph<'a>>,
     validation_message: &'a str,
     validation_glyph: Option<&'a Glyph<'a>>,
@@ -679,14 +705,18 @@ fn concatenate(strings: &[&str], output: &mut [u8]) {
     }
 }
 
+const MAX_REVIEW_PAGES: usize = 48;
+
 impl<'a> MultiFieldReview<'a> {
-    pub fn new(fields: &'a [Field<'a>],
-               review_message: &'a [&'a str],
-               review_glyph: Option<&'a Glyph<'a>>,
-               validation_message: &'a str,
-               validation_glyph: Option<&'a Glyph<'a>>,
-               cancel_message: &'a str,
-               cancel_glyph: Option<&'a Glyph<'a>>) -> Self {
+    pub fn new(
+        fields: &'a [Field<'a>],
+        review_message: &'a [&'a str],
+        review_glyph: Option<&'a Glyph<'a>>,
+        validation_message: &'a str,
+        validation_glyph: Option<&'a Glyph<'a>>,
+        cancel_message: &'a str,
+        cancel_glyph: Option<&'a Glyph<'a>>,
+    ) -> Self {
         MultiFieldReview {
             fields,
             review_message,
@@ -699,36 +729,62 @@ impl<'a> MultiFieldReview<'a> {
     }
 
     pub fn show(&self) -> bool {
+        testing::debug_print("Show review 1\n");
+        
         let mut buttons = ButtonsState::new();
 
         let first_page = match self.review_message.len() {
-            0 => {
-                Page::new(PageStyle::PictureNormal, ["", ""], self.review_glyph)
-            }
-            1 => {
-                Page::new(PageStyle::PictureBold, [self.review_message[0], ""], self.review_glyph)
-            }
-            _ => {
-                Page::new(PageStyle::PictureNormal, [self.review_message[0], self.review_message[1]], self.review_glyph)
-            }
+            0 => Page::new(PageStyle::PictureNormal, ["", ""], self.review_glyph),
+            1 => Page::new(
+                PageStyle::PictureBold,
+                [self.review_message[0], ""],
+                self.review_glyph,
+            ),
+            _ => Page::new(
+                PageStyle::PictureNormal,
+                [self.review_message[0], self.review_message[1]],
+                self.review_glyph,
+            ),
         };
-        let validation_page = Page::new(PageStyle::PictureBold, [self.validation_message, ""], self.validation_glyph);
-        let cancel_page = Page::new(PageStyle::PictureBold, [self.cancel_message, ""], self.cancel_glyph);
-        let mut review_pages: [Page; 32] = [Page::new(PageStyle::Normal, ["", ""], None); 32];
+
+        let validation_page = Page::new(
+            PageStyle::PictureBold,
+            [self.validation_message, ""],
+            self.validation_glyph,
+        );
+        let cancel_page = Page::new(
+            PageStyle::PictureBold,
+            [self.cancel_message, ""],
+            self.cancel_glyph,
+        );
+        let mut review_pages: [Page; MAX_REVIEW_PAGES] = [Page::new(PageStyle::Normal, ["", ""], None); MAX_REVIEW_PAGES];
         let mut total_page_count = 0;
- 
+
+        let mut max_chars_per_page = MAX_CHAR_PER_LINE * 3;
+        if cfg!(target_os = "nanos") {
+            max_chars_per_page = MAX_CHAR_PER_LINE;
+        }
+
+        testing::debug_print("Show review 2\n");
         // Determine each field page count
         for field in self.fields {
-            let field_page_count = (field.value.len() - 1) / MAX_CHAR_PER_LINE + 1;
-            // Create pages for each chunk of the field            
+            let field_page_count = (field.value.len() - 1) / max_chars_per_page + 1;
+            // Create pages for each chunk of the field
             for i in 0..field_page_count {
-                let start = i * MAX_CHAR_PER_LINE;
-                let end = (start + MAX_CHAR_PER_LINE).min(field.value.len());
+                let start = i * max_chars_per_page;
+                let end = (start + max_chars_per_page).min(field.value.len());
                 let chunk = &field.value[start..end];
+                
                 review_pages[total_page_count] = Page::new(PageStyle::BoldNormal, [field.name, chunk], None);
                 review_pages[total_page_count].chunk_count = field_page_count as u8;
                 review_pages[total_page_count].chunk_idx = (i + 1) as u8;
-                total_page_count += 1;
+                // Check if we have reached the maximum number of pages
+                // We need to keep 2 pages for the validation and cancel pages
+                total_page_count = if total_page_count < MAX_REVIEW_PAGES - 2 {
+                    total_page_count + 1
+                } else {
+                    break;
+                };
             }
         }
 
@@ -743,6 +799,7 @@ impl<'a> MultiFieldReview<'a> {
         RIGHT_ARROW.display();
 
         let mut cur_page = 0;
+        let mut refresh : bool = true;
         review_pages[cur_page].place();
 
         loop {
@@ -753,34 +810,37 @@ impl<'a> MultiFieldReview<'a> {
                             if cur_page > 0 {
                                 cur_page -= 1;
                             }
+                            refresh = true;
                         }
                         ButtonEvent::RightButtonRelease => {
                             if cur_page < total_page_count {
                                 cur_page += 1;
                             }
+                            refresh = true;
                         }
-                        ButtonEvent::BothButtonsRelease => 
-                        {
+                        ButtonEvent::BothButtonsRelease => {
                             if cur_page == total_page_count {
                                 // Cancel
                                 return false;
-                            }
-                            else if cur_page == total_page_count - 1 {
+                            } else if cur_page == total_page_count - 1 {
                                 // Validate
                                 return true;
                             }
                         }
-                        _ => (),
+                        _ => refresh = false,
                     }
-                    clear_screen();
-                    review_pages[cur_page].place();
-                    if cur_page > 0 {
-                        LEFT_ARROW.display();
+                    if refresh
+                    {
+                        clear_screen();
+                        review_pages[cur_page].place();
+                        if cur_page > 0 {
+                            LEFT_ARROW.display();
+                        }
+                        if cur_page < total_page_count {
+                            RIGHT_ARROW.display();
+                        }
+                        crate::screen_util::screen_update();
                     }
-                    if cur_page < total_page_count {
-                        RIGHT_ARROW.display();
-                    }
-                    crate::screen_util::screen_update();
                 }
                 _ => (),
             }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -501,17 +501,10 @@ impl<'a> MultiPageMenu<'a> {
             match self.comm.next_event() {
                 io::Event::Button(button) => {
                     match button {
-                        LeftButtonPress => {
-                            LEFT_S_ARROW.instant_display();
-                        }
-                        RightButtonPress => {
-                            RIGHT_S_ARROW.instant_display();
-                        }
                         BothButtonsRelease => return EventOrPageIndex::Index(index), 
                         b => {
                             match b {
                                 LeftButtonRelease => {
-                                    LEFT_S_ARROW.erase();
                                     if index as i16 - 1 < 0 {
                                         index = self.pages.len() - 1;
                                     } else {
@@ -519,7 +512,6 @@ impl<'a> MultiPageMenu<'a> {
                                     }
                                 }
                                 RightButtonRelease => {
-                                    RIGHT_S_ARROW.erase();
                                     if index < self.pages.len() - 1 {
                                         index += 1;
                                     } else {
@@ -755,16 +747,6 @@ impl<'a> MultiFieldReview<'a> {
 
         loop {
             match get_event(&mut buttons) {
-                Some(ButtonEvent::LeftButtonPress) => {
-                    if cur_page > 0 {
-                        LEFT_S_ARROW.instant_display();
-                    }
-                }
-                Some(ButtonEvent::RightButtonPress) => {
-                    if cur_page < total_page_count {
-                        RIGHT_S_ARROW.instant_display();
-                    }
-                }
                 Some(b) => {
                     match b {
                         ButtonEvent::LeftButtonRelease => {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,11 +1,18 @@
 #![allow(dead_code)]
 
-use ledger_sdk_sys::{seph, buttons::{get_button_event, ButtonEvent, ButtonsState}};
+use ledger_sdk_sys::{
+    buttons::{get_button_event, ButtonEvent, ButtonsState},
+    seph,
+};
 
-use crate::bagls::*;
+use nanos_sdk::{io, buttons::ButtonEvent::*};
+
+use crate::{bagls::*, fonts::OPEN_SANS};
 
 use crate::layout;
 use crate::layout::{Draw, Location, StringPlace};
+
+use crate::bitmaps::Glyph;
 
 /// Handles communication to filter
 /// out actual events, and converts key
@@ -300,6 +307,189 @@ impl<'a> Menu<'a> {
                 }
                 _ => (),
             }
+        }
+    }
+}
+
+pub enum PageStyle {
+    PictureNormal, // Picture (should be 16x16) with two lines of text (page layout depends on device).
+    PictureBold,   // Icon on top with one line of text on the bottom.
+    BoldNormal,    // One line of bold text and one line of normal text.
+    Normal,        // 2 lines of centered text.
+}
+
+pub struct Page<'a> {
+    style: PageStyle,
+    label: [&'a str; 2],
+    glyph: Option<&'a Glyph<'a>>,
+}
+
+// new_picture_normal
+impl<'a> From<([&'a str; 2], &'a Glyph<'a>)> for Page<'a> {
+    fn from((label, glyph): ([&'a str; 2], &'a Glyph<'a>)) -> Page<'a> {
+        Page::new(PageStyle::PictureNormal, label, Some(glyph))
+    }
+}
+
+// new bold normal or new normal
+impl<'a> From<([&'a str; 2], bool)> for Page<'a> {
+    fn from((label, bold): ([&'a str; 2], bool)) -> Page<'a> {
+        if bold {
+            Page::new(PageStyle::BoldNormal, label, None)
+        }
+        else
+        {
+            Page::new(PageStyle::Normal, label, None)
+        }
+    }
+}
+
+// new picture bold
+impl<'a> From<(&'a str, &'a Glyph<'a>)> for Page<'a> {
+    fn from((label, glyph): (&'a str, &'a Glyph<'a>)) -> Page<'a> {
+        let label = [label, ""];
+        Page::new(PageStyle::PictureBold, label, Some(glyph))
+    }
+}
+
+impl<'a> Page<'a> {
+    pub fn new(style: PageStyle, label: [&'a str; 2], glyph: Option<&'a Glyph<'a>>) -> Self {
+        Page {
+            style,
+            label,
+            glyph,
+        }
+    }
+
+    }
+
+    pub fn place(&self) {
+        clear_screen();
+        match self.style {
+            PageStyle::PictureNormal => {
+                let mut icon_x = 16;
+                let mut icon_y = 8;
+                if cfg!(target_os = "nanos") {
+                    self.label
+                        .place(Location::Middle, Layout::Custom(41), false);
+                } else {
+                    icon_x = 57;
+                    icon_y = 10;
+                    self.label
+                        .place(Location::Custom(28), Layout::Centered, false);
+                }
+                match self.glyph {
+                    Some(glyph) => {
+                        let icon = Icon::from(glyph);
+                        icon.set_x(icon_x).set_y(icon_y).display();
+                    }
+                    None => {}
+                }
+            }
+            PageStyle::PictureBold => {
+                let mut icon_x = 56;
+                let mut icon_y = 2;
+                if cfg!(target_os = "nanos") {
+                    self.label[0].place(Location::Bottom, Layout::Centered, true);
+                } else {
+                    icon_x = 57;
+                    icon_y = 17;
+                    self.label[0].place(Location::Custom(35), Layout::Centered, true);
+                }
+                match self.glyph {
+                    Some(glyph) => {
+                        let icon = Icon::from(glyph);
+                        icon.set_x(icon_x).set_y(icon_y).display();
+                    }
+                    None => {}
+                }
+            }
+            PageStyle::BoldNormal => {
+                let padding = 1;
+                let total_height = OPEN_SANS[0].height as usize
+                    + OPEN_SANS[1].height as usize
+                    + 2 * padding as usize;
+                let mut cur_y = Location::Middle.get_y(total_height);
+                self.label[0].place(Location::Custom(cur_y), Layout::Centered, true);
+                cur_y += OPEN_SANS[0].height as usize + 2 * padding as usize;
+                self.label[1].place(Location::Custom(cur_y), Layout::Centered, false);
+            }
+            PageStyle::Normal => {
+                self.label.place(Location::Middle, Layout::Centered, false);
+            }
+        }
+    }
+}
+
+pub enum EventOrPageIndex {
+    Event(io::Event<io::ApduHeader>),
+    Index(usize)
+}
+
+pub struct MultiPageMenu<'a> {
+    comm : &'a mut io::Comm,
+    pages: &'a [&'a Page<'a>],
+}
+
+impl<'a> MultiPageMenu<'a> {
+    pub fn new(comm: &'a mut io::Comm,  pages: &'a [&'a Page]) -> Self {
+        MultiPageMenu { comm, pages }
+    }
+
+    pub fn show(&mut self) -> EventOrPageIndex {
+        clear_screen();
+        
+        self.pages[0].place();
+
+        LEFT_ARROW.display();
+        RIGHT_ARROW.display();
+
+        crate::screen_util::screen_update();
+
+        let mut index = 0;
+
+        loop {
+            match self.comm.next_event() {
+                io::Event::Button(button) => {
+                    match button {
+                        LeftButtonPress => {
+                            LEFT_S_ARROW.instant_display();
+                        }
+                        RightButtonPress => {
+                            RIGHT_S_ARROW.instant_display();
+                        }
+                        BothButtonsRelease => return EventOrPageIndex::Index(index), 
+                        b => {
+                            match b {
+                                LeftButtonRelease => {
+                                    LEFT_S_ARROW.erase();
+                                    if index as i16 - 1 < 0 {
+                                        index = self.pages.len() - 1;
+                                    } else {
+                                        index = index.saturating_sub(1);
+                                    }
+                                }
+                                RightButtonRelease => {
+                                    RIGHT_S_ARROW.erase();
+                                    if index < self.pages.len() - 1 {
+                                        index += 1;
+                                    } else {
+                                        index = 0;
+                                    }
+                                }
+                                _ => (),
+                            }
+                            clear_screen();
+                            self.pages[index].place();
+                            LEFT_ARROW.display();
+                            RIGHT_ARROW.display();
+                            crate::screen_util::screen_update();
+                        }
+                    }
+                },
+                io::Event::Command(ins) => return EventOrPageIndex::Event(io::Event::Command(ins)),
+                _ => (),
+            };
         }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -322,8 +322,8 @@ impl<'a> Menu<'a> {
 pub enum PageStyle {
     PictureNormal, // Picture (should be 16x16) with two lines of text (page layout depends on device).
     PictureBold,   // Icon on top with one line of text on the bottom.
-    BoldNormal,    // One line of bold text and one line of normal text.
-    Normal,        // 2 lines of centered text.
+    BoldNormal, // One line of bold text and one line of normal text on Nano S or up to 3 lines on Nano X/SP.
+    Normal,     // 2 lines of centered text.
 }
 
 #[derive(Copy, Clone)]
@@ -420,15 +420,14 @@ impl<'a> Page<'a> {
             PageStyle::BoldNormal => {
                 let padding = 1;
                 let mut max_text_lines = 3;
-                if cfg!(target_os = "nanos")
-                {
+                if cfg!(target_os = "nanos") {
                     max_text_lines = 1;
                 }
-                let total_height = (OPEN_SANS[0].height * max_text_lines)  as usize
+                let total_height = (OPEN_SANS[0].height * max_text_lines) as usize
                     + OPEN_SANS[1].height as usize
                     + 2 * padding as usize;
                 let mut cur_y = Location::Middle.get_y(total_height);
-                
+
                 // Display the chunk count and index if needed
                 if self.chunk_count > 1 {
                     let mut label_bytes = [0u8; MAX_CHAR_PER_LINE];
@@ -450,16 +449,18 @@ impl<'a> Page<'a> {
                         ],
                         &mut label_bytes,
                     );
-                    from_utf8(&mut label_bytes).unwrap().trim_matches(char::from(0)).place(Location::Custom(cur_y), Layout::Centered, true);
+                    from_utf8(&mut label_bytes)
+                        .unwrap()
+                        .trim_end_matches(char::from(0))
+                        .place(Location::Custom(cur_y), Layout::Centered, true);
                 } else {
                     self.label[0].place(Location::Custom(cur_y), Layout::Centered, true);
                 }
                 cur_y += OPEN_SANS[0].height as usize + 2 * padding as usize;
-                
+
                 // If the device is a Nano S, display the second label as
                 // a single line of text
-                if cfg!(target_os = "nanos")
-                {
+                if cfg!(target_os = "nanos") {
                     self.label[1].place(Location::Custom(cur_y), Layout::Centered, false);
                 }
                 // Otherwise, display the second label as up to 3 lines of text
@@ -473,9 +474,12 @@ impl<'a> Page<'a> {
                         }
                         let end = (start + MAX_CHAR_PER_LINE).min(len);
                         indices[i] = (start, end);
-                        (&self.label[1][start..end]).place(Location::Custom(cur_y), Layout::Centered, false);
+                        (&self.label[1][start..end]).place(
+                            Location::Custom(cur_y),
+                            Layout::Centered,
+                            false,
+                        );
                         cur_y += OPEN_SANS[0].height as usize + 2 * padding as usize;
-                        
                     }
                 }
             }
@@ -730,7 +734,7 @@ impl<'a> MultiFieldReview<'a> {
 
     pub fn show(&self) -> bool {
         testing::debug_print("Show review 1\n");
-        
+
         let mut buttons = ButtonsState::new();
 
         let first_page = match self.review_message.len() {
@@ -757,7 +761,8 @@ impl<'a> MultiFieldReview<'a> {
             [self.cancel_message, ""],
             self.cancel_glyph,
         );
-        let mut review_pages: [Page; MAX_REVIEW_PAGES] = [Page::new(PageStyle::Normal, ["", ""], None); MAX_REVIEW_PAGES];
+        let mut review_pages: [Page; MAX_REVIEW_PAGES] =
+            [Page::new(PageStyle::Normal, ["", ""], None); MAX_REVIEW_PAGES];
         let mut total_page_count = 0;
 
         let mut max_chars_per_page = MAX_CHAR_PER_LINE * 3;
@@ -774,8 +779,9 @@ impl<'a> MultiFieldReview<'a> {
                 let start = i * max_chars_per_page;
                 let end = (start + max_chars_per_page).min(field.value.len());
                 let chunk = &field.value[start..end];
-                
-                review_pages[total_page_count] = Page::new(PageStyle::BoldNormal, [field.name, chunk], None);
+
+                review_pages[total_page_count] =
+                    Page::new(PageStyle::BoldNormal, [field.name, chunk], None);
                 review_pages[total_page_count].chunk_count = field_page_count as u8;
                 review_pages[total_page_count].chunk_idx = (i + 1) as u8;
                 // Check if we have reached the maximum number of pages
@@ -799,7 +805,7 @@ impl<'a> MultiFieldReview<'a> {
         RIGHT_ARROW.display();
 
         let mut cur_page = 0;
-        let mut refresh : bool = true;
+        let mut refresh: bool = true;
         review_pages[cur_page].place();
 
         loop {
@@ -829,8 +835,7 @@ impl<'a> MultiFieldReview<'a> {
                         }
                         _ => refresh = false,
                     }
-                    if refresh
-                    {
+                    if refresh {
                         clear_screen();
                         review_pages[cur_page].place();
                         if cur_page > 0 {


### PR DESCRIPTION
Add two new UI gadgets : 

* `MultiPageMenu` to display menus with pages that can have various styles : 
    - PictureNormal : Picture (should be 16x16) with two lines of text (page layout depends on device).
    - PictureBold : Icon on top with one line of text on the bottom.
    - BoldNormal : One line of bold text and one line of normal text on Nano S or up to 3 lines on Nano X/SP.
    - Normal : 2 lines of centered text.
 
  `MultiPageMenu` `new` function takes an `io::comm` as parameter so its `show` function can return a page index (in case of user "both button press") or any other event upon reception. It allows for any APDU to be received and processed when a menu is displayed.

* `MultiFieldReview` to review multiple fields with a review message at the start and validation/cancel messages at the end. The `show` function returns a boolean upon validation/cancellation by the user.